### PR TITLE
empty type setとメソッドだけも持っているinterfaceを区別するようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ method list:
 $ tslist fmt
 /usr/local/go/src/fmt/print.go:38:12: 
 State
-type set: empty
+type set: [any]
 method list:
 Write(b []byte) (n int, err error) 
 Width() (wid int, ok bool) 
@@ -111,25 +111,25 @@ Flag(c int) bool
 
 /usr/local/go/src/fmt/print.go:53:16: 
 Formatter
-type set: empty
+type set: [any]
 method list:
 Format(f fmt.State, verb rune) 
 
 /usr/local/go/src/fmt/print.go:62:15: 
 Stringer
-type set: empty
+type set: [any]
 method list:
 String() string
 
 /usr/local/go/src/fmt/print.go:70:17: 
 GoStringer
-type set: empty
+type set: [any]
 method list:
 GoString() string
 
 /usr/local/go/src/fmt/scan.go:21:16: 
 ScanState
-type set: empty
+type set: [any]
 method list:
 ReadRune() (r rune, size int, err error) 
 UnreadRune() error
@@ -140,7 +140,7 @@ Read(buf []byte) (n int, err error)
 
 /usr/local/go/src/fmt/scan.go:55:14: 
 Scanner
-type set: empty
+type set: [any]
 method list:
 Scan(state fmt.ScanState, verb rune) error
 ```

--- a/tslist.go
+++ b/tslist.go
@@ -134,6 +134,11 @@ func (v *Visitor) parseTypeSet() []TypeValue {
 	}
 
 	res := make([]TypeValue, 0, len(typeSet))
+	if len(v.typeResults) == 0 {
+		res = append(res, TypeValue{Name: ANY})
+		return res
+	}
+
 	// intersection
 	if _, ok := typeSet[ANY]; ok {
 		if len(typeSet) == 1 {


### PR DESCRIPTION
## やったこと
```
type i interface {
    int
    string
}
```
と
```
type Stringer interface {
    String() string
}
```
を区別するようにしました。
前者はどんな型も使えないですが、後者は`String() string`メソッドを持っているすべての型が対象になります